### PR TITLE
fixes issue #3

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -320,7 +320,11 @@ module Prawn
         cells_this_page = []
 
         @cells.each do |cell|
-          if cell.height > (cell.y + offset) - ref_bounds.absolute_bottom &&
+          # we only need to run this test on the first cell in a row
+          # check if the rows height fits on the page
+          # check if the row is not the first on that page (wouldn't make sense to go to next page in this case)
+          if cell.column == 0 &&
+             row(cell.row).height_with_span > (cell.y + offset) - ref_bounds.absolute_bottom &&
              cell.row > started_new_page_at_row
             # Ink all cells on the current page
             if defined?(@before_rendering_page) && @before_rendering_page

--- a/lib/prawn/table/cells.rb
+++ b/lib/prawn/table/cells.rb
@@ -182,6 +182,13 @@ module Prawn
         aggregate_cell_values(:row, :height_ignoring_span, :max)
       end
 
+      # Returns the total height of all rows in the selected set
+      # including spanned cells if the cell is the master cell
+      #
+      def height_with_span
+        aggregate_cell_values(:row, :height, :max)
+      end
+
       # Supports setting arbitrary properties on a group of cells.
       #
       #   table.cells.row(3..6).background_color = 'cc0000'


### PR DESCRIPTION
This fixes issue #3.

Earlier code checked on a cell by cell basis if it fits on the page. Now when the first (column 0) cell in a row is evaluated it checks if the whole row fits on the page otherwise breaking to a new page.

I added a function height_with_span to cells.rb which returns the height including any spanned cells if the spanning cell is the master cell. 

The height method (cells.rb) is a little misleading. It returns only the height excluding spanned cells.

To ensure the row heights calculation is not run unnecessarily it will only be done on the first (column 0) cell in a row.
