### PR TITLE
optionally allow text of a final row of a page to be split to the next page

### DIFF
--- a/lib/prawn/table/cell/span_dummy.rb
+++ b/lib/prawn/table/cell/span_dummy.rb
@@ -20,6 +20,9 @@ module Prawn
           @padding = [0, 0, 0, 0]
         end
 
+        # allow the corresponding master_cell to be read
+        attr_reader :master_cell
+
         # By default, a span dummy will never increase the height demand.
         #
         def natural_content_height
@@ -72,6 +75,11 @@ module Prawn
 
         def background_color
           @master_cell.background_color
+        end
+
+        # is this a SpanDummy for a rowspan?
+        def row_dummy?
+          (row != @master_cell.row)
         end
 
         private

--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -55,6 +55,7 @@ module Prawn
         # preset width.
         #
         def natural_content_height
+          return 0 if content.nil?
           with_font do
             b = text_box(:width => spanned_content_width + FPTolerance)
             b.render(:dry_run => true)

--- a/lib/prawn/table/cells.rb
+++ b/lib/prawn/table/cells.rb
@@ -175,6 +175,20 @@ module Prawn
         aggregate_cell_values(:column, :max_width_ignoring_span, :max)
       end
 
+      def recalculate_height
+        each do |cell|
+          cell.recalculate_height_ignoring_span
+        end
+        height
+      end
+
+      # reduce the y value in all cells by a given amount
+      def reduce_y(amount)
+        each do |cell|
+          cell.y -= amount
+        end
+      end
+
       # Returns the total height of all rows in the selected set.
       #
       def height

--- a/lib/prawn/table/splittable/split_cell.rb
+++ b/lib/prawn/table/splittable/split_cell.rb
@@ -1,0 +1,145 @@
+# encoding: utf-8
+
+module Prawn
+  class Table
+
+    # This class can do one thing well: split the content of a cell
+    # while doing this it also adjust the height of the cell to something reasonable
+    class SplitCell
+
+    def initialize(cell, cells=false)
+      @cell = cell
+      @cells = cells
+      if cell.content
+        @original_content = cell.content
+        @content_array = cell.content.split(' ')
+      end
+    end
+
+    attr_reader :cells
+
+    attr_accessor :cell
+
+
+    # split the content of the cell and adjust the height
+    def split(row_to_split, max_available_height)
+      # we don't process SpanDummy cells
+      return cell if cell.is_a?(Prawn::Table::Cell::SpanDummy)
+
+      return cell unless row_to_split == cell.row
+
+      # prepare everything for the while loop
+      # first we're gonna check if a single word fits the available space
+      i = 0
+      cell.content = @content_array[0]
+
+      content_that_fits = ''
+      while recalculate_height <= max_available_height
+        # content from last round
+        content_that_fits = content_old_page(i)
+        break if @content_array[i].nil?
+        i += 1
+        cell.content = content_old_page(i)
+      end
+      
+      split_content(content_that_fits, i)
+      
+      # recalcualte height for the cell in question
+      recalculate_height(include_dummy_cells: true)
+
+      return cell
+    end
+
+    # should we adjust the offset?
+    def adjust_offset?(final_cell_last_page)
+      return false unless move_cells_off_canvas?
+      (cell.y > final_cell_last_page.y)
+    end
+
+    # calculate extra offset
+    def extra_offset(max_cell_heights_cached, final_cell_last_page)
+      return 0 if adjust_offset?(final_cell_last_page)
+      return 0 unless move_cells_off_canvas?
+      return height_of_additional_already_printed_rows(cells.last_row, max_cell_heights_cached)
+    end
+
+    # should we move the cell off canvas?
+    def move_cells_off_canvas?
+      cells.new_page && 
+       !cell.is_a?(Prawn::Table::Cell::SpanDummy) &&
+       !cell.dummy_cells.empty? && 
+       cell.row < cells.last_row
+    end
+
+    # returns the height of any rows that have already been printed
+    def height_of_additional_already_printed_rows(last_row, max_cell_heights_cached)
+      ((cell.row+1..last_row)).map{ |row_number| max_cell_heights_cached[row_number]}.inject(:+)
+    end
+
+    # return array to be written to cells_this_page
+    def print(offset, max_cell_height_cached, final_cell_last_page, min_y)
+       # we might have to adjust the offset
+      adjust_offset = extra_offset(max_cell_height_cached, final_cell_last_page)
+       
+      # if the offset has to be adjusted, also correct the y position
+      cell.y = final_cell_last_page.y if adjust_offset?(final_cell_last_page)
+
+      y = cell.relative_y(offset - adjust_offset)
+
+      y = min_y if final_cell_last_page && min_y > 0 && cell.row <= final_cell_last_page.row && y < min_y
+
+      cell_for_page = [cell, [cell.relative_x, y]]
+    end
+
+    private
+
+    # recalculates the height of the cell and dummy cells if specified
+    def recalculate_height(options = {})
+      new_height = cell.recalculate_height_ignoring_span
+
+      return new_height unless options[:include_dummy_cells] == true
+
+      # if a height was set for this cell, use it if the text didn't have to be split
+      # cell.height = cell.original_height if cell.content == old_content && !cell.original_height.nil?
+      # and its dummy cells
+      cell.dummy_cells.each do |dummy_cell|
+        dummy_cell.recalculate_height_ignoring_span
+      end      
+    
+      return new_height
+    end
+
+    # splits the content
+    def split_content(content_that_fits, i)
+      # did anything fit at all?
+      if !content_that_fits || content_that_fits.length == 0
+        cell.content = @original_content
+        return
+      end
+
+      cell.content = content_that_fits
+      cell.content_new_page = calculate_content_new_page(cell, i)
+    end
+
+    # return the content for a new page, based on the existing content_new_page
+    # and the calculated position in the content array where the cell is now split
+    def calculate_content_new_page(cell, i)
+      content_new_page = cell.content_new_page
+      if !cell.content_new_page.nil? && !(content_new_page(i).nil? || content_new_page(i) == '')
+        content_new_page = ' ' + content_new_page 
+      end
+      content_new_page(i) + (content_new_page   || '' )
+    end
+
+    # returns the content that should be printed to the old page
+    def content_old_page(i)
+      @content_array[0..i].join(' ')
+    end
+
+    # returns the content that should be printed to the new page
+    def content_new_page(i)
+      @content_array[i..-1].join(' ')
+    end
+  end
+end
+end

--- a/lib/prawn/table/splittable/split_cells.rb
+++ b/lib/prawn/table/splittable/split_cells.rb
@@ -1,0 +1,315 @@
+# encoding: utf-8
+
+module Prawn
+  class Table
+
+    # This class knows everything about splitting an array of cells
+    class SplitCells
+
+      def initialize(cells, options = {})
+        @cells = cells
+        @current_row_number = options[:current_row_number]
+        @new_page = options[:new_page]
+        @table = options[:table]
+        @cells_this_page_option = options[:cells_this_page]
+        compensate_offset_for_height = 0
+      end
+
+      # allow this class to access the rows of the table
+      def rows(row_spec)
+        table.rows(row_spec)
+      end
+      alias_method :row, :rows
+
+      attr_accessor :cells
+
+      # the table associated with this instance
+      attr_reader :table
+
+      attr_reader :new_page
+
+      # change content to the one needed for the new page
+      def adjust_content_for_new_page
+        cells.each do |cell|
+          cell = handle_cells_this_page(cell)
+          cell.content = cell.content_new_page
+        end
+      end
+
+      # cells_this_page and split_cells are formatted differently
+      # adjust accordingly for cells.each calls
+      def handle_cells_this_page(cell)
+        return cell[0] if @cells_this_page_option
+        return cell
+      end
+
+      # adjust the height of the cells
+      def adjust_height_of_cells(options = {})
+        cells_we_have_passed = []
+        @cells.each do |cell|
+          cell = handle_cells_this_page(cell)
+
+          next if options[:skip_rows] && options[:skip_rows].include?(cell.row)
+
+          # remember that we've passed this cell (for future dummy cells)
+          #
+          # ensure that the array is two dimensional
+          cells_we_have_passed[cell.row]=[] if cells_we_have_passed[cell.row].nil?
+          # remember
+          cells_we_have_passed[cell.row][cell.column] = true
+          # skip cell if it is a dummy cell not included in the set of cells we
+          # are looping through
+          if cell.is_a?(Prawn::Table::Cell::SpanDummy)
+            master_cell = cell.master_cell
+            next if cells_we_have_passed[master_cell.row].nil? || cells_we_have_passed[master_cell.row][master_cell.column].nil?
+          end
+
+          # height of the current cell
+          height_of_cell = max_row_height(cell) || 0
+          puts "cell #{cell.row}/#{cell.column} height=#{height_of_cell} (sc 69)"
+          if options[:min_row_height] && !cell.is_a?(Prawn::Table::Cell::SpanDummy) && cell.row != last_row
+            min_row_height = options[:min_row_height][cell.row] || 0
+            height_of_cell =  min_row_height if min_row_height > height_of_cell
+          end
+
+          puts "cell #{cell.row}/#{cell.column} height=#{height_of_cell} (sc 75)"
+          puts "cell #{cell.row}/#{cell.column} min_row_height=#{options[:min_row_height]} (sc 76)"
+          puts "cell #{cell.row}/#{cell.column} extra_height_for_row_dummies=#{extra_height_for_row_dummies(cell)} (sc 77)"
+
+          row_dummies_height = extra_height_for_row_dummies(cell)
+          if !@new_page && options[:min_row_height]
+            #row_dummies_height = 93+30
+            min_height = 0
+            cell.filtered_dummy_cells(last_row, @new_page).each do |dummy_cell|
+              next unless dummy_cell.column == cell.column
+              if dummy_cell.row != last_row
+                puts "cell #{cell.row}/#{cell.column} adding dummy height for row #{dummy_cell.row} of #{options[:min_row_height][dummy_cell.row] || 0}"
+                min_height += options[:min_row_height][dummy_cell.row] || 0
+              else
+                min_height += row(dummy_cell.row).height
+              end
+            end
+            row_dummies_height = min_height if min_height > row_dummies_height
+          end
+
+
+          # account for other rows that this cell spans
+          cell.height = height_of_cell + row_dummies_height
+        end
+      end
+
+      # we don't want to resize header cells and cells from earlier pages
+      # (that span into the current one) on the final page
+      def adjust_height_of_final_cells(header_rows, first_row_new_page, options = {})
+        skip_row_numbers = []
+        # don't resize the header
+        header_rows.each do |cell|
+          skip_row_numbers.push cell.row
+        end
+        # don't resize cells from former pages (that span into this page)
+        0..first_row_new_page.times do |i|
+          skip_row_numbers.push i
+        end
+        skip_row_numbers.uniq!
+
+        cells.each do |cell, stuff|
+          puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (sc 116)"
+        end
+
+        options[:skip_rows] = skip_row_numbers
+        adjust_height_of_cells(options)
+
+        cells.each do |cell, stuff|
+          puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (sc 122)"
+        end
+
+
+        return cells
+      end
+
+      # calculate the maximum height of each row
+      def max_cell_heights(force_reload = false)
+        # cache the result
+        return @max_cell_heights if !force_reload && defined? @max_cell_heights
+
+        @max_cell_heights = Hash.new(0)
+        cells.each do |cell|
+          cell = handle_cells_this_page(cell)
+          next if cell.content.nil? || cell.content.empty? 
+
+          # if we are on the new page, change the content of the cell
+          # cell.content = cell.content_new_page if hash[:new_page]
+
+          # calculate the height of the cell includign any cells it may span
+          respect_original_height = true unless @new_page
+          cell_height = cell.calculate_height_ignoring_span(respect_original_height)
+
+          # account for the height of any rows this cell spans (new page)
+          cell_height -= height_of_row_dummies(cell)
+
+          @max_cell_heights[cell.row] = cell_height if @max_cell_heights[cell.row] < cell_height
+        end
+        
+        @max_cell_heights
+      end
+      
+      attr_accessor :compensate_offset_for_height
+
+      # calculate by how much we have to compensate the offset
+      def compensate_offset
+        (max_cell_height.values.max || 0) - compensate_offset_for_height
+      end
+
+      # remove any cells from the cells array that are not needed on the new page
+      def cells_new_page
+        # is there some content to display coming from the last row on the last page?
+        # found_some_content_in_the_last_row_on_the_last_page = false
+        # cells.each do |split_cell|
+        #   next unless split_cell.row == last_row_number_last_page
+        #   found_some_content_in_the_last_row_on_the_last_page = true unless split_cell.content_new_page.nil? || split_cell.content_new_page.empty?
+        # end
+
+        cells_new_page = []
+        cells.each do |split_cell|
+          split_cell = handle_cells_this_page(split_cell)
+          next if irrelevant_cell?(split_cell)
+
+          # all tests passed. print it - meaning add it to the array
+          cells_new_page.push split_cell
+        end
+
+        cells_new_page
+      end
+
+      # return the cells to be used on the old page
+      def cells_old_page
+        # obviously we wouldn't have needed a function for this,
+        # but it makes the code more readable at the place
+        # that calls this function
+        cells
+      end
+
+      # the number of the first row
+      def first_row
+        return cells.first[0].row if @cells_this_page_option
+        cells.first.row
+      end
+
+      # the number of the last row
+      def last_row
+        return cells.last[0].row if @cells_this_page_option
+        cells.last.row
+      end
+
+      # resplit the content
+      # meaning that we ensure that the content really fits
+      # into the cell on the old page and resplit it if necessary
+      def resplit_content
+        cells.each do |cell|
+          cell.height = 0 unless cell.is_a?(Prawn::Table::Cell::SpanDummy)
+
+          max_available_height = rows(first_row..last_row).height
+
+          Prawn::Table::SplitCell.new(cell).split(cell.row, max_available_height)
+        end
+        return cells
+      end
+
+      def min_y
+        last_row_last_page = 0
+        if @new_page && !cells.empty?
+          min_y = nil
+          compensate_height = 0
+          cells.each do |c, stuff|
+            if min_y.nil? || min_y > stuff[1]
+              min_y = stuff[1] 
+              compensate_height = c.height
+            end
+          end
+        end
+        return (min_y || 0) - (compensate_height || 0)
+      end
+
+      private
+
+      # cells that aren't located in the last row and that don't span
+      # the last row with an attached dummy cell are irrelevant
+      # for the splitting process
+      def irrelevant_cell?(cell)
+        # don't print cells that don't span anything and that 
+        # aren't located in the last row
+        return true if cell.row < last_row_number_last_page &&
+                       cell.dummy_cells.empty? && 
+                       !cell.is_a?(Prawn::Table::Cell::SpanDummy)
+
+        # if they do span multiple cells, check if at least one of them
+        # is located in the last row of the last page
+        if !cell.dummy_cells.empty?
+          found_a_cell_in_the_last_row_on_the_last_page = false
+          cell.dummy_cells.each do |dummy_cell|
+            found_a_cell_in_the_last_row_on_the_last_page = true if dummy_cell.row == last_row_number_last_page
+          end
+          return true unless found_a_cell_in_the_last_row_on_the_last_page
+        end
+        return false
+      end
+
+      # the row number of the last row on the last page
+      def last_row_number_last_page
+        @current_row_number - 1
+      end
+
+      # how much height should we allocated for the rows that are spanned by
+      # the row dummies
+      def extra_height_for_row_dummies(cell)
+        relevant_cells = cell.filtered_dummy_cells(last_row, @new_page)
+        row_numbers = calculate_row_numbers(relevant_cells)
+        puts "cell #{cell.row}/#{cell.column} row_numbers=#{row_numbers} #{rows([13,14]).height} #{max_cell_heights(true)[13]}"
+        return new_height_of_row_dummies(row_numbers) || 0
+      end
+
+      # recalculate the height of the rows in question
+      def new_height_of_row_dummies(row_numbers)
+        if @new_page
+          return rows(row_numbers).height
+          # return row_numbers.map { |row_number| row(row_number).recalculate_height }.inject(:+)
+        else
+          return row_numbers.map{ |row_number| max_cell_heights[row_number]}.inject(:+)
+        end
+      end
+
+      # sets the height of the cell to the maximum of all given cells
+      def max_row_height(cell)
+        return if cell.is_a?(Prawn::Table::Cell::SpanDummy)
+
+        # if multiple cells of multiple rows are split it may happen that the cell
+        # holding the text (and which will be rendered) is from an earlier row than
+        # the last row on the last page (and thus the first row on the new page)
+        # in this case set the height of this cell to the first line of the new page
+        # otherwise just take the newely calculated row height
+        first_row_new_page = max_cell_heights.keys.min || 0
+
+        if cell.row < first_row_new_page
+          return max_cell_heights[first_row_new_page]
+        else
+          return max_cell_heights[cell.row]
+        end
+      end
+
+      # calculate the height of all rows that the dummy cells of the given cell span
+      def height_of_row_dummies(cell)
+        height = 0
+        row_numbers = calculate_row_numbers(cell.dummy_cells)
+        row_numbers.each do |row_number|
+          height += row(row_number).height
+        end
+        return height
+      end
+
+      # return the numbers of all rows in the given set of cells
+      def calculate_row_numbers(cells)
+        cells.map { |dummy_cell| dummy_cell.row if dummy_cell.row_dummy? }.uniq.compact
+      end
+    end
+  end
+end

--- a/lib/prawn/table_splittable.rb
+++ b/lib/prawn/table_splittable.rb
@@ -1,0 +1,265 @@
+# encoding: utf-8
+
+require_relative 'table/splittable/split_cell'
+require_relative 'table/splittable/split_cells'
+
+module Prawn
+  # This class is an extension to Prawn::Table
+  # It allows the final row on a page to be split accross two pages
+  class TableSplittable < Table
+
+    # option passed to TableSplittable indicating that this table
+    # should split final rows on a page if needed.
+    attr_accessor :split_cells_across_pages
+
+
+    # this is the main function that is called from Prawn::Table.draw
+    # it processes all the cells, positioning them onto the table
+    # and splitting them if needed
+    def process_cells(ref_bounds, started_new_page_at_row, offset)
+
+      cells_this_page = []
+      split_cells = []
+      splitting = false
+      @min_row_height = {}
+
+      @cells.each do |cell|
+        puts "cell #{cell.row}/#{cell.column} height=#{cell.height} content=#{cell.content}"
+        # should we split cells?
+        if split_cells?(cell)
+          # the main work of splitting the cells of a row (here only for one cell) between two pages
+          cell, split_cells, cells_this_page, splitting, offset, started_new_page_at_row = process_split_cell(cell, offset, ref_bounds, splitting, started_new_page_at_row, split_cells, cells_this_page)
+        elsif start_new_page?(cell, offset, ref_bounds)
+          # draw cells on the current page and then start a new one
+          # this will also add a header to the new page if a header is set
+          # reset array of cells for the new page
+          cells_this_page, offset = ink_and_draw_cells_and_start_new_page(cells_this_page, cell)
+
+          # remember the current row for background coloring
+          started_new_page_at_row = cell.row
+        end
+
+        # Set background color, if any.
+        cell = set_background_color(cell, started_new_page_at_row)
+        
+        if splitting
+          # remember this cell
+          split_cells.push cell
+        else
+          # add the current cell to the cells array for the current page
+          cells_this_page << [cell, [cell.relative_x, cell.relative_y(offset)]]
+        end
+      end
+
+      cells_this_page, offset = print_split_cells_on_final_page(split_cells, cells_this_page, offset, splitting)
+
+      cells_object = Prawn::Table::SplitCells.new(cells_this_page, cells_this_page: true, table: self)
+
+      cells_this_page.each do |cell, stuff|
+        puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (ts 59)"
+      end
+
+      cells_this_page = cells_object.adjust_height_of_final_cells(header_rows, started_new_page_at_row, min_row_height: @min_row_height)
+
+      cells_this_page.each do |cell, stuff|
+        puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (ts 65)"
+      end
+
+      return cells_this_page, offset
+    end
+
+    # takes care of the splitting and printing for a single cell
+    def process_split_cell(cell, offset, ref_bounds, splitting, started_new_page_at_row, split_cells, cells_this_page)
+      @row_to_split ||= -1
+      @original_height ||= 0
+
+      max_available_height = (cell.y + offset) - ref_bounds.absolute_bottom
+
+       # should the row be split?
+      if start_new_page?(cell, offset, ref_bounds, true) && max_available_height > 0
+        @row_to_split = cell.row
+        @original_height = cell.height
+        splitting = true
+      end
+
+      pre_height = cell.height_of_cell
+
+      puts "cell #{cell.row}/#{cell.column} height=#{cell.height} (ts 78)"
+
+      # split cell content and adjust height of cell
+      cell = Prawn::Table::SplitCell.new(cell).split(@row_to_split, max_available_height) if pre_height > max_available_height || !cell.dummy_cells.empty?
+
+      puts "cell #{cell.row}/#{cell.column} height=#{cell.height} (ts 83)"
+
+      if print_split_cells?(split_cells, cell, max_available_height, started_new_page_at_row)
+        # are we really splitting anything?
+        # if not reset instruction to split (@row_to_split) and height of current cell
+        @row_to_split = -1
+        cell.height = pre_height if cell.content_new_page = ''
+
+        cells_this_page, offset = print_split_cells(cells_this_page, split_cells, cell, offset, @original_height)
+
+        split_cells = []
+        splitting=false
+        
+        # remember the current row for background coloring
+        started_new_page_at_row = cell.row
+      end
+      @min_row_height[cell.row - 1] = row_height_without_span(cell.row - 1) if @min_row_height[cell.row - 1].nil?
+
+      return cell, split_cells, cells_this_page, splitting, offset, started_new_page_at_row
+    end
+
+    def row_height_without_span(row_number)
+      row_height = 0
+      cells.each do |cell|
+        next unless cell.row == row_number
+        next unless cell.dummy_cells.empty?
+        row_height = cell.height_of_cell if row_height < cell.height_of_cell
+      end
+      row_height
+    end
+
+    # the final page needs some special treatment
+    def print_split_cells_on_final_page(split_cells, cells_this_page, offset, splitting)
+      print_split_cells_single_page(split_cells, cells_this_page, offset)
+
+      if splitting
+        # draw cells on the current page and then start a new one
+        # this will also add a header to the new page if a header is set
+        # reset array of cells for the new page
+        cells_this_page, offset = ink_and_draw_cells_and_start_new_page(cells_this_page, @cells.last)
+
+        # draw split cells on to the new page
+        print_split_cells_single_page(split_cells, cells_this_page, offset, new_page: true, current_row: @cells.last.row)
+      end
+
+      return cells_this_page, offset
+    end
+
+    # are all cells in this row normal text cells without any fancy formatting we can't easily handle when splitting cells
+    def only_plain_text_cells(row_number)
+      row(row_number).each do |cell|
+        return true if cell.is_a?(Prawn::Table::Cell::SpanDummy)
+
+        if !cell.is_a?(Prawn::Table::Cell::Text) ||
+           cell.rotate ||
+           cell.rotate_around ||
+           cell.leading || 
+           cell.single_line
+          return false
+        end
+      end
+      return true
+    end
+
+    # "print" cells that have been split onto a page
+    # print means - add it to the cells_this_page array
+    # this function will be used multiple times, once on the old and once on the new page
+    def print_split_cells_single_page(split_cells, cells_this_page, offset, hash={})
+      split_cells.each do |cell|
+        puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (ts 152)"
+      end
+      cells_this_page.each do |cell, stuff|
+        puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (ts 155)"
+      end
+      cells_object = Prawn::Table::SplitCells.new(split_cells, table: self, new_page: hash[:new_page])
+      cells_object.adjust_content_for_new_page if hash[:new_page]
+      
+      @max_cell_height = cells_object.max_cell_heights
+
+
+
+      cells_object.adjust_height_of_cells(min_row_height: @min_row_height)
+      
+      min_y = Prawn::Table::SplitCells.new(cells_this_page, cells_this_page: true, new_page: hash[:new_page]).min_y
+
+      cells_object.cells.each do |split_cell|
+        cell = Prawn::Table::SplitCell.new(split_cell, cells_object)
+        
+        cell_to_print = cell.print(offset, @max_cell_height_cached, @final_cell_last_page, min_y)
+        last_row_last_page = @final_cell_last_page.row if @final_cell_last_page
+
+        cells_this_page << cell_to_print if cell_to_print[0].height > 0
+
+        row(split_cell.row).reduce_y(-2000) if cell.move_cells_off_canvas?
+      end
+
+      cells_this_page.each do |cell, stuff|
+        puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (ts 180)"
+      end
+
+      @max_cell_height_cached = cells_object.max_cell_heights(true)
+      return (@max_cell_height.values.max || 0)
+    end
+
+    # ink and draw cells, then start a new page
+    def ink_and_draw_cells_and_start_new_page(cells_this_page, cell, split_cells=false, offset=false)
+      # print any remaining cells to be split
+      print_split_cells_single_page(split_cells, cells_this_page, offset) if offset
+
+      @final_cell_last_page = split_cells.last if split_cells
+
+      @min_row_height = {}
+
+      cells_this_page.each do |cell, stuff|
+        puts "cell #{cell.row}/#{cell.column} height=#{cell.height_of_cell} (ts 197)"
+      end
+
+      super
+    end
+
+    private
+
+    # should we split cells at all?
+    def split_cells?(cell)
+      (defined?(@split_cells_across_pages) && @split_cells_across_pages && only_plain_text_cells(cell.row))
+    end
+
+    # is it time to print the split cells?
+    def print_split_cells?(split_cells, cell, max_available_height, started_new_page_at_row)
+
+      cell_height = cell.calculate_height_ignoring_span
+            
+      # (cell_height > max_available_height && 
+      #  cell.row > started_new_page_at_row && 
+      #  !cell.is_a?(Prawn::Table::Cell::SpanDummy) && 
+      #  !split_cells.empty?)
+
+      (cell_height > max_available_height && 
+       cell.row > started_new_page_at_row && 
+       !cell.is_a?(Prawn::Table::Cell::SpanDummy))
+    end
+
+    # print the cells that have been split
+    # it will acutally write/print the cells onto the old page
+    # for the new page print only means adding it to the cells_this_page variable
+    def print_split_cells(cells_this_page, split_cells, cell, offset, original_height)
+      # recalculate / resplit content for split_cells array
+      # this may be necessary because a cell that spans multiple rows did not
+      # know anything about needed height changes in subsequent rows when the text was split
+      # e.g. original n+1 lines where able to be printed in the remaining space, however
+      # a splitting of a later row resulted in a table that was smaller than the theoretical
+      # maximum that was used in the original calculation (for example due to the padding)
+      # thus the last line can't be printed because there is only space for n lines
+      cells_object = Prawn::Table::SplitCells.new(split_cells, table: self, current_row_number: cell.row)
+      
+      # O(n^2) on the cells about to be split
+      # maybe we can improve this at some point in the future
+      cells_object.resplit_content
+
+      # draw cells on the current page and then start a new one
+      # this will also add a header to the new page if a header is set
+      # reset array of cells for the new page
+      cells_this_page, offset = ink_and_draw_cells_and_start_new_page(cells_this_page, cell, cells_object.cells_old_page, offset)
+
+      # any remaining cells to be split will have been split by the ink_and_draw_cells_and_start_new_page command
+
+      # draw split cells on to the new page
+      split_cell_height = print_split_cells_single_page(cells_object.cells_new_page, cells_this_page, offset - original_height, new_page: true, current_row: cell.row)
+      offset -= split_cell_height
+
+      return cells_this_page, offset
+    end
+  end
+end

--- a/manual/table/splitting_cells.rb
+++ b/manual/table/splitting_cells.rb
@@ -1,0 +1,31 @@
+# encoding: utf-8
+#
+# <b> This is an optional and experimential feature!</b>
+#
+# While it is known to work in many use cases, it is rather new code and not (yet) widely used, thus
+# the possibility for bugs is higher than usual.
+#
+# To activate this feature you need to pass <i>split_cells_across_pages</i> to the table command.
+#
+# This will result in cells not being forced to a single page. The text can freely flow to the
+# next page.
+#
+# This feature only supports plain text cells. The cells of rotated text, images and sub tables
+# are still forced onto a single page.
+
+require File.expand_path(File.join(File.dirname(__FILE__),
+                                   %w[.. example_helper]))
+
+filename = File.basename(__FILE__).gsub('.rb', '.pdf')
+Prawn::ManualBuilder::Example.generate(filename) do
+  
+  # generate some text that will be split across two pages
+  lorem_ipsum_string = "This will be a very long cell that is split accross two pages. "
+  150.times { |i| lorem_ipsum_string += i.to_s + ' ' }
+
+  data = [ [{ content: lorem_ipsum_string, rowspan: 18, width: 100 },
+            { content: "foo 0", height: 30 }]]
+  17.times { |i| data.push [{ content: "foo #{i+1}", height: 30 }] }
+
+  table data, split_cells_across_pages: true
+end

--- a/manual/table/table.rb
+++ b/manual/table/table.rb
@@ -35,6 +35,10 @@ Prawn::ManualBuilder::Example.generate("table.pdf", :page_size => "FOLIO") do
       s.example "style"
     end
 
+    p.section "Splitting cells if necessary" do |s|
+      s.example "splitting_cells"
+    end
+
     p.intro do
       prose("Prawn comes with table support out of the box. Tables can be styled in whatever way you see fit. The whole table, rows, columns and cells can be styled independently from each other.
 

--- a/spec/split_cells_spec.rb
+++ b/spec/split_cells_spec.rb
@@ -1,0 +1,165 @@
+# encoding: utf-8
+
+# run rspec -t issue:XYZ  to run tests for a specific github issue
+# or  rspec -t unresolved to run tests for all unresolved issues
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "spec_helper")
+
+require_relative "../lib/prawn/table"
+require 'set'
+
+# test suite for the functionality that enables us to split rows in a table
+# if the last row on a single page does not fully fit onto that page
+#
+# beware that lots of possible rendering issues of lines are not covered
+# by this test suite
+# what it does try to cover is the rendering of the text
+describe "Prawn::Table" do
+  describe "split cells in the final row of a page (1)" do
+    before(:each) do
+      @pdf = Prawn::Document.new
+      @data = []
+      # just enough lines, so that the next one will break if it uses more than one line
+      29.times do |i| 
+        @data.push ["row #{i}/1", "row#{i}/2", "row#{i}/3", "row#{i}/4", "row#{i}/5", "row#{i}/6"]
+      end
+
+      # data with header
+      @data_with_header = []
+      3.times do |i|
+        @data_with_header.push(["head #{i}/1", "head#{i}/2", "head#{i}/3", "head#{i}/4", "head#{i}/5", "head#{i}/6"])
+      end
+      26.times do |i|
+        @data_with_header.push ["row #{i}/1", "row#{i}/2", "row#{i}/3", "row#{i}/4", "row#{i}/5", "row#{i}/6"]
+      end
+    end
+
+    it 'should split the last row if the option is set' do
+      @data.push ["this line is too long"]*6
+      @pdf.table(@data, column_widths: 80, split_cells_across_pages: true)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq ["too long"]*6
+    end
+
+    it 'should not split the last row if the option is unset' do
+      @data.push ["this line is too long"]*6
+      @pdf.table(@data, column_widths: 80)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq  ["this line is", "too long", "this line is", "too long", "this line is", "too long", "this line is", "too long", "this line is", "too long", "this line is", "too long"]
+    end
+
+    it 'preserves header when splitting cells' do
+      @data_with_header
+      @data_with_header.push ["this line is too long"]*6
+
+      # header: true
+      @pdf.table(@data_with_header, column_widths: 80, split_cells_across_pages: true, header: true)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq ["head 0/1", "head0/2", "head0/3", "head0/4", "head0/5", "head0/6", "too long", "too long", "too long", "too long", "too long", "too long"]
+    end
+
+    it 'preserves multiple header when splitting cells' do
+      @data_with_header
+      @data_with_header.push ["this line is too long"]*6
+     
+      # header: 3
+      @pdf.table(@data_with_header, column_widths: 80, split_cells_across_pages: true, header: 3)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq ["head 0/1", "head0/2", "head0/3", "head0/4", "head0/5", "head0/6", "head 1/1", "head1/2", "head1/3", "head1/4", "head1/5", "head1/6", "head 2/1", "head2/2", "head2/3", "head2/4", "head2/5", "head2/6", "too long", "too long", "too long", "too long", "too long", "too long"]
+    end
+
+    it 'preserves colspan when splitting cells' do
+      @data.push [{content: "this line is too long to fit in two columns and only one row", colspan: 2}]*3
+      @pdf.table(@data, column_widths: 80, split_cells_across_pages: true)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq ["two columns and only one", "row", "two columns and only one", "row", "two columns and only one", "row"]
+    end
+
+    it 'preserves colspan and headers when splitting cells' do
+      @data_with_header.push [{content: "this line is too long to fit in two columns and only one row", colspan: 2}]*3
+      @pdf.table(@data_with_header, column_widths: 80, split_cells_across_pages: true, header: true)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq  ["head 0/1", "head0/2", "head0/3", "head0/4", "head0/5", "head0/6", "two columns and only one", "row", "two columns and only one", "row", "two columns and only one", "row"]
+    end
+
+    it 'preserves colspanned rows and colspanned headers when splitting cells' do
+      @data_with_header[0] = [{content: "head0/1", colspan: 2}, {content: "head0/2", colspan: 2}, {content: "head0/3", colspan: 2}]
+      @data_with_header.push [{content: "this line is too long to fit in two columns and only one row", colspan: 2}]*3
+      @pdf.table(@data_with_header, column_widths: 80, split_cells_across_pages: true, header: true)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq  ["head0/1", "head0/2", "head0/3", "two columns and only one", "row", "two columns and only one", "row", "two columns and only one", "row"]
+    end
+
+    it 'preserves rowspanned header rows when splitting cells' do
+      @data_with_header[0] = [{content: "head0/1", rowspan: 2, colspan: 2}, {content: "head0/2", colspan: 2}, {content: "head0/3", colspan: 2}]
+      @data_with_header[1] = [{content: "head0/2", colspan: 2}, {content: "head0/3", colspan: 2}] 
+      @data_with_header.push [{content: "this line is too long to fit in two columns and only one row", colspan: 2}]*3
+      @pdf.table(@data_with_header, column_widths: 80, split_cells_across_pages: true, header: 2)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      # puts @data_with_header
+      output.pages[1][:strings].should eq ["head0/1", "head0/2", "head0/3", "head0/2", "head0/3", "two columns and only one", "row", "two columns and only one", "row", "two columns and only one", "row"]
+    end
+
+    it 'can split rowspanned rows' do
+      # todo
+    end
+  end
+
+  describe 'some complex scenarios trying to cover multiple points of failure' do
+    it 'shows complex scenario 1', focus: true do
+      @pdf = Prawn::Document.new
+      @data = []
+      # just enough lines, so that the next one will break if it uses more than one line
+      @data.push [{content: 'header1', rowspan: 2, colspan: 2}, {content: 'header1', colspan: 2}, {content: 'header1', colspan: 2}]
+      @data.push [{content: 'header2', colspan: 2}, {content: 'header2', colspan: 2}]
+      25.times do |i| 
+        @data.push ["row #{i}/1", "row#{i}/2", "row#{i}/3", "row#{i}/4", "row#{i}/5", "row#{i}/6"]
+      end
+      @data.push [{content: "this is a very long line that needs a lot of space", rowspan: 4}, "row26/2", "row26/3", "row26/4", "row26/5", "row26/6"]
+      @data.push [ {content: 'foobar'}, {content: "this line is too long to fit in two columns and only one row", colspan: 2}, {content: 'final cell colspan 2', colspan: 2}]
+      @data.push [  "row -2 /2", "row -2 /3", "row -2 /4", "row -2 /5", "row -2 /6"]
+      @data.push [ "row -1 /2", "row -1 /3", "row -1 /4", "row -1 /5", "row -1 /6"]
+      @data.push [ "row last/1", "row last/2", "row last/3", "row last/4", "row last/5", "row last/6"]
+      @table = @pdf.table(@data, column_widths: 80, split_cells_across_pages: true, header: 3)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq  ["header1", "header1", "header1", "header2", "header2", "row 0/1", "row0/2", "row0/3", "row0/4", "row0/5", "row0/6", "of space", "row", "row -2 /2", "row -2 /3", "row -2 /4", "row -2 /5", "row -2 /6", "row -1 /2", "row -1 /3", "row -1 /4", "row -1 /5", "row -1 /6", "row last/1", "row last/2", "row last/3", "row last/4", "row last/5", "row last/6"]
+    end
+
+    it 'shows complex scenario 2', focus: true do
+      @pdf = Prawn::Document.new
+      @data = []
+      # just enough lines, so that the next one will break if it uses more than one line
+      @data.push [{content: 'header1', rowspan: 2, colspan: 2}, {content: 'header1', colspan: 2}, {content: 'header1', colspan: 2}]
+      @data.push [{content: 'header2', colspan: 2}, {content: 'header2', colspan: 2}]
+      25.times do |i| 
+        @data.push ["row #{i}/1", "row#{i}/2", "row#{i}/3", "row#{i}/4", "row#{i}/5", "row#{i}/6"]
+      end
+      @data.push ["row 25/1", {content: "row25/2"}, "row25/3", "row25/4", "row25/5", "row25/6"]
+      @data.push [{content: "this is a very long line that needs a lot of space", rowspan: 4}, "row26/2", "row26/3", "row26/4", "row26/5", "row26/6"]
+      @data.push [ {content: 'foobar'}, {content: "this line is too long to fit in two columns and only one row", colspan: 2}, {content: 'final cell colspan 2', colspan: 2}]
+      @data.push [  "row -2 /2", "row -2 /3", "row -2 /4", "row -2 /5", "row -2 /6"]
+      @data.push [ "row -1 /2", "row -1 /3", "row -1 /4", "row -1 /5", "row -1 /6"]
+      @data.push [ "row last/1", "row last/2", "row last/3", "row last/4", "row last/5", "row last/6"]
+      @table = @pdf.table(@data, column_widths: 80, split_cells_across_pages: true, header: 3)
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq ["header1", "header1", "header1", "header2", "header2", "row 0/1", "row0/2", "row0/3", "row0/4", "row0/5", "row0/6", "needs a lot", "of space", "two columns and only one", "row", "row -2 /2", "row -2 /3", "row -2 /4", "row -2 /5", "row -2 /6", "row -1 /2", "row -1 /3", "row -1 /4", "row -1 /5", "row -1 /6", "row last/1", "row last/2", "row last/3", "row last/4", "row last/5", "row last/6"]
+    end
+
+    it 'shows complex scenario 3', focus: true do
+      @pdf = Prawn::Document.new
+      rows = []
+      50.times do |i|
+        cols = []
+        cols << "foo #{i} / 0"
+        cols << {content: "very long cell", rowspan: 50} if i == 0
+        cols << "foo #{i} / 2"
+        rows << cols
+      end
+      @pdf.table(rows,
+                split_cells_across_pages: true,
+                cell_style: {inline_format: true})
+      output = PDF::Inspector::Page.analyze(@pdf.render)
+      output.pages[1][:strings].should eq  ["foo 30 / 0", "foo 30 / 2", "foo 31 / 0", "foo 31 / 2", "foo 32 / 0", "foo 32 / 2", "foo 33 / 0", "foo 33 / 2", "foo 34 / 0", "foo 34 / 2", "foo 35 / 0", "foo 35 / 2", "foo 36 / 0", "foo 36 / 2", "foo 37 / 0", "foo 37 / 2", "foo 38 / 0", "foo 38 / 2", "foo 39 / 0", "foo 39 / 2", "foo 40 / 0", "foo 40 / 2", "foo 41 / 0", "foo 41 / 2", "foo 42 / 0", "foo 42 / 2", "foo 43 / 0", "foo 43 / 2", "foo 44 / 0", "foo 44 / 2", "foo 45 / 0", "foo 45 / 2", "foo 46 / 0", "foo 46 / 2", "foo 47 / 0", "foo 47 / 2", "foo 48 / 0", "foo 48 / 2", "foo 49 / 0", "foo 49 / 2"]
+    end
+  end
+end


### PR DESCRIPTION
<i>New pull request based of current master and squashing all commits of branch hb_split_table_rows (#16) and hb_split_table_rows_refactor_1. It is related to issue #3.</i>

This pull request implements an optional feature that will allow rows to be split between two pages. Thus if a text in the last row of a page does not fit onto the current page the row and the text will be split between the current and the next page.

To activate this feature you have to pass the ````split_cells_across_pages: true```` option to the table command.
This pull request also includes an update to the manual describing the new feature.

The new code conforms to codeclimate A rating and due to more good quality code it raises the current average rating of prawn-table. https://codeclimate.com/github/prawnpdf/prawn-table/compare/hb_split_table
The old code has - as far as possible - not been touched. Thus the rating for it stays more or less the same (in fact it is a little bit worse due to a few added lines.)

I'll leave this pull request open for a couple of days before merging into master. Any comments are greatly appreciated.