### PR TITLE
resolves #45 use background_color method to access background_color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Updated supported ruby versions to match Prawn. PR #47
+* All cells in a rowspan use the background color of the master (i.e., first) cell (#45)
 
 ## 0.2.1
 

--- a/lib/prawn/table/cell.rb
+++ b/lib/prawn/table/cell.rb
@@ -710,11 +710,11 @@ module Prawn
       # Draws the cell's background color.
       #
       def draw_background(pt)
-        if defined?(@background_color) && @background_color
-          @pdf.mask(:fill_color) do
-            @pdf.fill_color @background_color
-            @pdf.fill_rectangle pt, width, height
-          end
+        return unless background_color
+
+        @pdf.mask(:fill_color) do
+          @pdf.fill_color background_color
+          @pdf.fill_rectangle pt, width, height
         end
       end
 

--- a/spec/table/span_dummy_spec.rb
+++ b/spec/table/span_dummy_spec.rb
@@ -6,12 +6,21 @@ require 'set'
 describe "Prawn::Table::Cell::SpanDummy" do
   before(:each) do
     @pdf = Prawn::Document.new
-    @table = @pdf.table([[{:content => "Row", :colspan => 2}]])
-    @master_cell = @table.cells[0,0]
-    @span_dummy  = @master_cell.dummy_cells.first
+    @table = @pdf.table([
+        [{:content => "A1-2", :colspan => 2}, {:content => "A-B3", :rowspan => 2}],
+        [{:content => "B1-2", :colspan => 2}]
+    ], :row_colors => [nil, 'EFEFEF'])
+    @colspan_master = @table.cells[0,0]
+    @colspan_dummy = @colspan_master.dummy_cells.first
+    @rowspan_master = @table.cells[0,2]
+    @rowspan_dummy = @table.cells[1,2]
   end
 
-  it "delegates background_color to the master cell" do
-    @span_dummy.background_color.should == @master_cell.background_color
+  it "colspan dummy delegates background_color to the master cell" do
+    @colspan_dummy.background_color.should == @colspan_master.background_color
+  end
+
+  it "rowspan dummy delegates background_color to the master cell" do
+    @rowspan_dummy.background_color.should == @rowspan_master.background_color
   end
 end


### PR DESCRIPTION
- use background_color method to access background_color to honor rowspan
- add test for rowspan cell background color
- alternating row colors will no longer bleed through rowspan