### PR TITLE
Update tested ruby versions to match Prawn.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ rvm:
   - 2.1
   - 2.2
   - rbx-2
-  - jruby
+  - jruby9k
 env:
-  JRUBY_OPTS=--2.0
+  JRUBY_OPTS=--dev
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.2
+  - 2.0
+  - 2.1
+  - 2.2
   - rbx-2
-  - jruby-19mode
+  - jruby
+env:
+  JRUBY_OPTS=--2.0
 matrix:
   allow_failures:
     - rvm: rbx-2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Updated supported ruby versions to match Prawn. PR #47
+
 ## 0.2.1
 
 * Allow the use of Prawn `2.x`, as it should not break table behavior.


### PR DESCRIPTION
We no longer support ruby 1.9, so this updates travis to only test
against the ruby versions we support.