### PR TITLE
skip applying properties from table cell_style on cells with own style

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -135,6 +135,7 @@ module Prawn
     #   above for details on available options.
     #
     def initialize(data, document, options={}, &block)
+      @initializing = true
       @pdf = document
       @cells = make_cells(data)
       @header = false
@@ -147,6 +148,8 @@ module Prawn
       set_column_widths
       set_row_heights
       position_cells
+      
+      @initializing = false
     end
 
     # Number of rows in the table.
@@ -232,7 +235,8 @@ module Prawn
     #   pdf.table(data, :cell_style => { :borders => [:left, :right] })
     #
     def cell_style=(style_hash)
-      cells.style(style_hash)
+      # skip applying table cell style on initialization
+      cells.style(style_hash.merge skip_existing: @initializing)
     end
 
     # Allows generic stylable content. This is an alternate syntax that some

--- a/lib/prawn/table/cell.rb
+++ b/lib/prawn/table/cell.rb
@@ -232,10 +232,12 @@ module Prawn
       #
       #   cell.padding = 0
       #   cell.border_width = 2
+      # +skip_existing+::
+      #   Parameter for skipping general table cell style if presents local cell style
       #
       def style(options={}, &block)
         options.each do |k, v|
-          send("#{k}=", v) if respond_to?("#{k}=")
+          send("#{k}=", v) if respond_to?("#{k}=") && (!options[:skip_existing] || send(k).nil?)
         end
 
         # The block form supports running a single block for multiple cells, as


### PR DESCRIPTION
fix [Incorrect cell styling](https://github.com/prawnpdf/prawn-table/issues/56)