### PR TITLE
Use a cell's specified font to determine text cell content width. #42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master
 
-* Bugfix: Use the cell's specifed font to calculate the cell width. (Jesse Doyle, PR [#60](https://github.com/prawnpdf/prawn-table/pull/60), issue [#42](https://github.com/prawnpdf/prawn-table/issues/42))
+* Bugfix: Use the cell's specified font to calculate the cell width. (Jesse Doyle, PR [#60](https://github.com/prawnpdf/prawn-table/pull/60), issue [#42](https://github.com/prawnpdf/prawn-table/issues/42))
 
 ## 0.2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+* Bugfix: Use the cell's specifed font to calculate the cell width. (Jesse Doyle, #42)
+
 ## 0.2.3
 
 * Allow padding of subtables to be configurable. PR #44

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master
 
-* Bugfix: Use the cell's specifed font to calculate the cell width. (Jesse Doyle, #42)
+* Bugfix: Use the cell's specifed font to calculate the cell width. (Jesse Doyle, PR [#60](https://github.com/prawnpdf/prawn-table/pull/60), issue [#42](https://github.com/prawnpdf/prawn-table/issues/42))
 
 ## 0.2.3
 

--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -134,7 +134,8 @@ module Prawn
         # Returns the width of +text+ under the given text options.
         #
         def styled_width_of(text)
-          @pdf.width_of(text, @text_options)
+          options = @text_options.reject { |k| k == :style }
+          with_font { @pdf.width_of(text, options) }
         end
 
         private

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -536,6 +536,12 @@ describe "Prawn::Table::Cell" do
       c.font.name.should == 'Helvetica-Bold'
     end
 
+    it "should use the specified font to determine font metrics" do
+      c = cell(:content => 'text', :font => 'Courier', :font_style => :bold)
+      font = @pdf.find_font('Courier-Bold')
+      c.content_width.should == font.compute_width_of("text")
+    end
+
     it "should allow style to be changed after initialize" do
       c = cell(:content => "text")
       c.font_style = :bold


### PR DESCRIPTION
Previously the `styled_width_of` method in `cell/text.rb` seemed to use the document's current font for all text width calculations. 

This PR changes that behaviour to use the cell's particular font if specified, then use the document's current font.

The previous behaviour was causing a bug with [Prawn::Icon](https://github.com/jessedoyle/prawn-icon/issues/21), and I'm sure others have encountered this bug in the past (#42).
