### PR TITLE
Use require instead of require_relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 * Bugfix: Use the cell's specified font to calculate the cell width. (Jesse Doyle, PR [#60](https://github.com/prawnpdf/prawn-table/pull/60), issue [#42](https://github.com/prawnpdf/prawn-table/issues/42))
+* Use `require` instead of `require_relative` to avoid dual loading files
 
 ## 0.2.3
 

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -8,14 +8,14 @@
 
 
 require 'prawn'
-require_relative 'table/column_width_calculator'
-require_relative 'table/cell'
-require_relative 'table/cells'
-require_relative 'table/cell/in_table'
-require_relative 'table/cell/text'
-require_relative 'table/cell/subtable'
-require_relative 'table/cell/image'
-require_relative 'table/cell/span_dummy'
+require 'prawn/table/column_width_calculator'
+require 'prawn/table/cell'
+require 'prawn/table/cells'
+require 'prawn/table/cell/in_table'
+require 'prawn/table/cell/text'
+require 'prawn/table/cell/subtable'
+require 'prawn/table/cell/image'
+require 'prawn/table/cell/span_dummy'
 
 module Prawn
   module Errors


### PR DESCRIPTION
Using `require_relative` can cause files to be loaded multiple times. An [example project](https://github.com/wconrad/rspec-duplicate-require) was created to show off this issue with rspec.

Here is the issue being exposed using prawn.
```
rrosenblum@C02NV0KSG3QN:~/work/test$ ls -la
total 32
drwxr-xr-x   8 rrosenblum  staff   272 Mar 18 14:12 .
drwxr-xr-x  44 rrosenblum  staff  1496 Mar 17 18:58 ..
drwxr-xr-x   3 rrosenblum  staff   102 Mar 17 18:59 .bundle
-rw-r--r--   1 rrosenblum  staff     6 Mar 17 18:58 .ruby-version
-rw-r--r--   1 rrosenblum  staff    52 Mar 18 14:12 Gemfile
-rw-r--r--   1 rrosenblum  staff   225 Mar 18 14:12 Gemfile.lock
drwxr-xr-x   3 rrosenblum  staff   102 Mar 17 18:59 vendor
lrwxr-xr-x   1 rrosenblum  staff     6 Mar 17 18:59 vendor2 -> vendor
rrosenblum@C02NV0KSG3QN:~/work/test$ cat Gemfile
source 'https://rubygems.org'

gem 'prawn', '2.2.2'
rrosenblum@C02NV0KSG3QN:~/work/test$ bundle config
Settings are listed in order of priority. The top value will be used.
jobs
Set for the current user (/Users/rrosenblum/.bundle/config): "3"

path
Set for your local app (/Users/rrosenblum/work/test/.bundle/config): "vendor2/bundle"
Set for the current user (/Users/rrosenblum/.bundle/config): "vendor/bundle"

disable_shared_gems
Set for your local app (/Users/rrosenblum/work/test/.bundle/config): "true"

rrosenblum@C02NV0KSG3QN:~/work/test$ bundle exec irb
irb(main):001:0> require 'prawn'
/Users/rrosenblum/work/test/vendor2/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:12: warning: already initialized constant PDF::Core::Text::VALID_OPTIONS
/Users/rrosenblum/work/test/vendor/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:12: warning: previous definition of VALID_OPTIONS was here
/Users/rrosenblum/work/test/vendor2/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:13: warning: already initialized constant PDF::Core::Text::MODES
/Users/rrosenblum/work/test/vendor/bundle/ruby/2.3.0/gems/pdf-core-0.7.0/lib/pdf/core/text.rb:13: warning: previous definition of MODES was here
=> true
irb(main):002:0>
```