### PR TITLE
Calculate cell width of multi-line cells correctly

### DIFF
--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -135,7 +135,13 @@ module Prawn
         #
         def styled_width_of(text)
           options = @text_options.reject { |k| k == :style }
-          with_font { @pdf.width_of(text, options) }
+          if text.empty?
+            0
+          else
+            with_font do
+              text.lines.map { |line| @pdf.width_of(line, options) }.max
+            end
+          end
         end
 
         private

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -104,6 +104,11 @@ describe "Prawn::Table::Cell" do
       expect(c.width).to eq @pdf.width_of("text") + c.padding[1] + c.padding[3]
     end
 
+    it "should be calculated for multiline text" do
+      c = cell(:content => "text\na\nb")
+      expect(c.width).to eq @pdf.width_of("text") + c.padding[1] + c.padding[3]
+    end
+
     it "should be overridden by manual :width" do
       c = cell(:content => "text", :width => 400)
       expect(c.width).to eq 400
@@ -130,6 +135,11 @@ describe "Prawn::Table::Cell" do
 
     it "content_width should exclude padding" do
       c = cell(:content => "text", :padding => 10)
+      expect(c.content_width).to eq @pdf.width_of("text")
+    end
+
+    it "content_width should exclude padding with multiple lines" do
+      c = cell(:content => "text\na\nb", :padding => 10)
       expect(c.content_width).to eq @pdf.width_of("text")
     end
 


### PR DESCRIPTION
Ensures that the optimal cell width is calculated correctly when the column's content contains more than one line.

This is similar to #50 but with specs.

Fixes #49.