### PR TITLE
Sync the Ruby versions with Prawn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,14 @@
 language: ruby
 before_install:
+  - gem update --system
   - gem install bundler
   - bundle --version
 rvm:
-  - 2.0.0-p0
-  - 2.0.0-p648
   - 2.1.0-p0
-  - 2.1.8
+  - 2.1.10
   - 2.2.0-p0
-  - 2.2.4
+  - 2.2.6
   - 2.3.0
-  - rbx-2
-  - jruby-9.0.4.0
-matrix:
-  include:
-    - rvm: jruby-1.7.22
-      env: JRUBY_OPTS=--2.0
-  allow_failures:
-    - rvm: rbx-2
+  - 2.3.3
+  - 2.4.0
+  - jruby-9.1.7.0


### PR DESCRIPTION
Currently we have unsupported Ruby versions on our configuration, also
the 2.0.0-p0 version is not available causing the tests to fail.

This PR along with #94 will make the tests pass again.