### PR TITLE
Allow setting disable_wrap_by_char option on cell text

### DIFF
--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -17,7 +17,7 @@ module Prawn
 
         TextOptions = [:inline_format, :kerning, :size, :align, :valign,
           :rotate, :rotate_around, :leading, :single_line, :skip_encoding,
-          :overflow, :min_font_size]
+          :overflow, :min_font_size, :disable_wrap_by_char]
 
         TextOptions.each do |option|
           define_method("#{option}=") { |v| @text_options[option] = v }


### PR DESCRIPTION
Added in Prawn 1.2, disable_wrap_by_char allows text boxes to disable
wrapping by character. When used with :shrink_to_fit overflow option,
this will shrink the word all the way down to fit it in a single
unbroken line, instead of having mid-word line breaks.