### PR TITLE
Allow time values to be added to a table cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+* Enhancement: Allow time values to be added to a table cell. (Michael MacDonald, PR [#103](https://github.com/prawnpdf/prawn-table/pull/103))
 * Bugfix: Use the cell's specified font to calculate the cell width. (Jesse Doyle, PR [#60](https://github.com/prawnpdf/prawn-table/pull/60), issue [#42](https://github.com/prawnpdf/prawn-table/issues/42))
 
 ## 0.2.3

--- a/lib/prawn/table/cell.rb
+++ b/lib/prawn/table/cell.rb
@@ -162,7 +162,7 @@ module Prawn
       def self.make(pdf, content, options={})
         at = options.delete(:at) || [0, pdf.cursor]
         content = content.to_s if content.nil? || content.kind_of?(Numeric) ||
-          content.kind_of?(Date)
+          content.kind_of?(Date) || content.kind_of?(Time)
 
         if content.is_a?(Hash)
           if content[:image]

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -36,7 +36,7 @@ describe "Prawn::Table::Cell" do
     end
 
     it "should convert nil, Numeric, and Date values to strings" do
-      [nil, 123, 123.45, Date.today].each do |value|
+      [nil, 123, 123.45, Date.today, Time.new].each do |value|
         c = @pdf.cell(:content => value)
         expect(c).to be_a_kind_of Prawn::Table::Cell::Text
         expect(c.content).to eq value.to_s


### PR DESCRIPTION
Just the minimum change to allow Time values to be added to a table cell in the same way as for a Date value. Currently, I have to perform a `to_s` on any time values before outputting to a table cell.