### PR TITLE
resolves #114 position table using indent instead of bounding_box

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -672,27 +672,24 @@ module Prawn
       y_positions.each_with_index { |y, i| row(i).y = y }
     end
 
-    # Sets up a bounding box to position the table according to the specified
-    # :position option, and yields.
+    # Adjusts the box padding to position the table according to the specified
+    # :position option, then yields.
     #
     def with_position
-      x = case defined?(@position) && @position || :left
-          when :left   then return yield
-          when :center then (@pdf.bounds.width - width) / 2.0
-          when :right  then  @pdf.bounds.width - width
-          when Numeric then  @position
+      pad_left, pad_right = case defined?(@position) && @position || :left
+          when :left   then [0, 0]
+          when :center then [(@pdf.bounds.width - width) / 2.0] * 2
+          when :right  then [@pdf.bounds.width - width, 0]
+          when Numeric then [@position, 0]
           else raise ArgumentError, "unknown position #{@position.inspect}"
           end
-      dy = @pdf.bounds.absolute_top - @pdf.y
-      final_y = nil
-
-      @pdf.bounding_box([x, @pdf.bounds.top], :width => width) do
-        @pdf.move_down dy
+      if pad_left > 0
+        @pdf.indent pad_left, pad_right do
+          yield
+        end
+      else
         yield
-        final_y = @pdf.y
       end
-
-      @pdf.y = final_y
     end
 
   end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -689,22 +689,34 @@ describe "Prawn::Table" do
     end
 
     describe "position" do
+      it "should not position table if :position => :left" do
+        expect(@pdf).not_to receive(:indent)
+
+        @pdf.table([["foo"]], :column_widths => 500, :position => :left)
+      end
+
       it "should center tables with :position => :center" do
-        expect(@pdf).to receive(:bounding_box).with([(@pdf.bounds.width - 500) / 2.0, anything], kind_of(Hash))
+        expect(@pdf).to receive(:indent).with((@pdf.bounds.width - 500) / 2.0, (@pdf.bounds.width - 500) / 2.0)
 
         @pdf.table([["foo"]], :column_widths => 500, :position => :center)
       end
 
       it "should right-align tables with :position => :right" do
-        expect(@pdf).to receive(:bounding_box).with([@pdf.bounds.width - 500, anything], kind_of(Hash))
+        expect(@pdf).to receive(:indent).with(@pdf.bounds.width - 500, 0)
 
         @pdf.table([["foo"]], :column_widths => 500, :position => :right)
       end
 
       it "should accept a Numeric" do
-        expect(@pdf).to receive(:bounding_box).with([123, anything], kind_of(Hash))
+        expect(@pdf).to receive(:indent).with(123, 0)
 
         @pdf.table([["foo"]], :column_widths => 500, :position => 123)
+      end
+
+      it "should not position table if table width matches width of bounds" do
+        expect(@pdf).not_to receive(:indent)
+
+        @pdf.table([["foo"]], :column_widths => @pdf.bounds.width, :position => :center)
       end
 
       it "should raise_error an ArgumentError on unknown :position" do


### PR DESCRIPTION
- position table using indent instead of align
- don't attempt to position table if table spans width of bounds