### PR TITLE
Add Time to the class of values that can be used in a cell.  Avoid error when value is passed in options

### DIFF
--- a/lib/prawn/table/cell.rb
+++ b/lib/prawn/table/cell.rb
@@ -161,20 +161,16 @@ module Prawn
       #
       def self.make(pdf, content, options={})
         at = options.delete(:at) || [0, pdf.cursor]
-        content = content.to_s if content.nil? || content.kind_of?(Numeric) ||
-          content.kind_of?(Date)
+
+        return Cell::Image.new(pdf, at, content) if content.is_a?(Hash) && content[:image]
 
         if content.is_a?(Hash)
-          if content[:image]
-            return Cell::Image.new(pdf, at, content)
-          end
           options.update(content)
           content = options[:content]
-        else
-          options[:content] = content
         end
 
-        options[:content] = content = "" if content.nil?
+        content = content.to_s if stringify_content?(content)
+        options[:content] = content
 
         case content
         when Prawn::Table::Cell
@@ -189,6 +185,15 @@ module Prawn
         else
           raise Errors::UnrecognizedTableContent
         end
+      end
+
+      def self.stringify_content?(content)
+        return true if content.nil?
+        return true if content.kind_of?(Numeric)
+        return true if content.kind_of?(Date)
+        return true if content.kind_of?(Time)
+
+        false
       end
 
       # A small amount added to the bounding box width to cover over floating-

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -36,8 +36,16 @@ describe "Prawn::Table::Cell" do
     end
 
     it "should convert nil, Numeric, and Date values to strings" do
-      [nil, 123, 123.45, Date.today].each do |value|
+      [nil, 123, 123.45, Date.today, Time.new].each do |value|
         c = @pdf.cell(:content => value)
+        expect(c).to be_a_kind_of Prawn::Table::Cell::Text
+        expect(c.content).to eq value.to_s
+      end
+    end
+
+    it "should convert nil, Numeric, and Date values to strings when value is extracted from options" do
+      [nil, 123, 123.45, Date.today, Time.new].each do |value|
+        c = Prawn::Table::Cell.make(@pdf, {}, { :content => value })
         expect(c).to be_a_kind_of Prawn::Table::Cell::Text
         expect(c.content).to eq value.to_s
       end


### PR DESCRIPTION
This is a combination of #103 and #119 with tests for both cases.  Thanks to @schlick and @tetsuya-ogawa for the original PRs.

@pointlessone Since the original PRs overlap, and tests were only included in one of them, I think this is a good combination PR.  Missing tests were added.

It also makes it easy to add future types to be stringified and, should it be desired, to change the behavior to stringify anything but `Prawn::Table`, `Prawn::Table::Cell`,  or Array that responds to a `to_s`

@gettalong any comments are welcome as well.