### PR TITLE
Fixes #43 - Migrate error from Prawn to prawn-table

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -26,6 +26,10 @@ module Prawn
     # This error is raised when an empty or nil table is rendered
     #
     EmptyTable = Class.new(StandardError)
+
+    # Raised when unrecognized content is provided for a table cell.
+    #
+    UnrecognizedTableContent = Class.new(StandardError) unless defined?(::Prawn::Errors::UnrecognizedTableContent)
   end
 
   # Next-generation table drawing for Prawn.


### PR DESCRIPTION
Addresses the prawn-table side of #43 

This defines an error constant in prawn-table if it is not already defined.  This allows us to safely remove it from prawn, and for the gem to work with versions of prawn that define it (or not)

@pointlessone This allows addressing the `prawn` side of #43 with the next release.