### PR TITLE
Fix a typo (workflow name) in the CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Prawn::Table
 
 [![Gem Version](https://badge.fury.io/rb/prawn-table.png)](http://badge.fury.io/rb/prawn-table)
-![Build Status](https://github.com/prawnpdf/prawn-table/actions/workflows/tests.yml/badge.svg)
+![Build Status](https://github.com/prawnpdf/prawn-table/actions/workflows/ci.yml/badge.svg)
 [![Code Climate](https://codeclimate.com/github/prawnpdf/prawn-table.png)](https://codeclimate.com/github/prawnpdf/prawn-table)
 ![Maintained: PRs accepted](https://img.shields.io/badge/maintained-PRs_accepted-orange.png)
 


### PR DESCRIPTION
With the merging of various sources for CI contributions, the badge name doesn't match the workflow name so the badge doesn't show.  This corrects the name of the badge

@pointlessone This is a trivial fix that should be merged.