### PR TITLE
Keep more specific cell styling instead of it being overwritten by the table cell_style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Master
 
+* Bugfix: Use a cell's custom style over table styles. (PR [#59](https://github.com/prawnpdf/prawn-table/pull/59), issue [#65](https://github.com/prawnpdf/prawn-table/issues/56))
 * Bugfix: Use the cell's specified font to calculate the cell width. (Jesse Doyle, PR [#60](https://github.com/prawnpdf/prawn-table/pull/60), issue [#42](https://github.com/prawnpdf/prawn-table/issues/42))
 
 ## 0.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Master
 
-* Bugfix: Use a cell's custom style over table styles. (PR [#59](https://github.com/prawnpdf/prawn-table/pull/59), issue [#65](https://github.com/prawnpdf/prawn-table/issues/56))
+* Bugfix: Use a cell's custom style over table styles. (PR [#143](https://github.com/prawnpdf/prawn-table/pull/143), issue [#56](https://github.com/prawnpdf/prawn-table/issues/56))
 * Bugfix: Use the cell's specified font to calculate the cell width. (Jesse Doyle, PR [#60](https://github.com/prawnpdf/prawn-table/pull/60), issue [#42](https://github.com/prawnpdf/prawn-table/issues/42))
 
 ## 0.2.3

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -139,10 +139,13 @@ module Prawn
     #   above for details on available options.
     #
     def initialize(data, document, options={}, &block)
+      table_opts = options.dup
       @pdf = document
-      @cells = make_cells(data, options.delete(:cell_style) || {})
+      @cells = make_cells(data, table_opts.delete(:cell_style) || {})
       @header = false
-      options.each { |k, v| send("#{k}=", v) }
+      table_opts.each do |k, v|
+        send("#{k}=", v) if respond_to?("#{k}=")
+      end
 
       if block
         block.arity < 1 ? instance_eval(&block) : block[self]

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -528,10 +528,10 @@ module Prawn
 
           # Build the cell and store it in the Cells collection.
           cell = if cell_data.is_a?(Hash)
-            Cell.make(@pdf, cell_style.merge(cell_data))
-          else
-            Cell.make(@pdf, cell_data, cell_style)
-          end
+                   Cell.make(@pdf, cell_style.merge(cell_data))
+                 else
+                   Cell.make(@pdf, cell_data, cell_style)
+                 end
           cells[row_number, column_number] = cell
 
           # Add dummy cells for the rest of the cells in the span group. This

--- a/lib/prawn/table/cell.rb
+++ b/lib/prawn/table/cell.rb
@@ -224,7 +224,7 @@ module Prawn
         @rowspan = 1
         @dummy_cells = []
 
-        options.each { |k, v| send("#{k}=", v) }
+        style(options)
 
         @initializer_run = true
       end

--- a/manual/table/style.rb
+++ b/manual/table/style.rb
@@ -27,7 +27,7 @@ Prawn::ManualBuilder::Example.generate(filename) do
   move_down 20
 
   table(
-    [['A', 'B'],['C', { content: 'D', text_color: 'ff0000' }]],
+    [%w[A B], ['C', { content: 'D', text_color: 'ff0000' }]],
     cell_style: { text_color: '0000ff' }
   )
 end

--- a/manual/table/style.rb
+++ b/manual/table/style.rb
@@ -7,6 +7,11 @@
 # also accepts a block that will be called for each cell and can be used for
 # some complex styling.
 #
+# Individual cell styles can also be applied when defining the data for the
+# table using a hash syntax for the cell.  This style will take precedence over
+# any table level cell styles.  See the "cell_text" section for a list of
+# options.
+
 require File.expand_path(File.join(File.dirname(__FILE__),
                                    %w[.. example_helper]))
 
@@ -19,4 +24,10 @@ Prawn::ManualBuilder::Example.generate(filename) do
       c.background_color = ((c.row + c.column) % 2).zero? ? '000000' : 'ffffff'
     end
   end
+  move_down 20
+
+  table(
+    [['A', 'B'],['C', { content: 'D', text_color: 'ff0000' }]],
+    cell_style: { text_color: '0000ff' }
+  )
 end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1618,9 +1618,9 @@ describe "colspan / rowspan" do
     t = @pdf.table([['col1', 'col2'],
                     ['val1', { content: 'val2', align: :left }]],
                    cell_style: { align: :center })
-    t.cells[0, 0].align.should == :center
-    t.cells[0, 1].align.should == :center
-    t.cells[1, 0].align.should == :center
-    t.cells[1, 1].align.should == :left
+    expect(t.cells[0, 0].align).to eq :center
+    expect(t.cells[0, 1].align).to eq :center
+    expect(t.cells[1, 0].align).to eq :center
+    expect(t.cells[1, 1].align).to eq :left
   end
 end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1613,4 +1613,14 @@ describe "colspan / rowspan" do
     pdf.render
     expect(pdf.page_count).to eq 1
   end
+
+  it 'illustrates issue #56 cell style should not be overwritten by table style', issue: 56 do
+    t = @pdf.table([['col1', 'col2'],
+                    ['val1', { content: 'val2', align: :left }]],
+                   cell_style: { align: :center })
+    t.cells[0, 0].align.should == :center
+    t.cells[0, 1].align.should == :center
+    t.cells[1, 0].align.should == :center
+    t.cells[1, 1].align.should == :left
+  end
 end


### PR DESCRIPTION
This is a rebased and updated version of #59, which addressed #56.

Thanks to @russellsanders for the original contribution.

@pointlessone I believe this can be merged.  Can you please take a look?