### PR TITLE
add in / fix handling of fallback fonts

### DIFF
--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -134,8 +134,7 @@ module Prawn
         # Returns the width of +text+ under the given text options.
         #
         def styled_width_of(text)
-          options = @text_options.reject { |k| k == :style }
-          with_font { @pdf.width_of(text, options) }
+          with_font { text_box(width: 10_000).used_width }
         end
 
         private

--- a/prawn-table.gemspec
+++ b/prawn-table.gemspec
@@ -20,14 +20,15 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('prawn', '>= 1.3.0', '< 3.0.0')
 
-  spec.add_development_dependency('pdf-inspector', '~> 1.1.0')
   spec.add_development_dependency('yard')
   spec.add_development_dependency('rspec', '~> 3.0')
   spec.add_development_dependency('rake')
   spec.add_development_dependency('simplecov')
+
+  spec.add_development_dependency('pdf-inspector', '>= 1.2.1', '< 2.0.a')
+  spec.add_development_dependency('pdf-reader', '~> 1.4', '>= 1.4.1')
   spec.add_development_dependency('prawn-dev', '~> 0.3.0')
-  spec.add_development_dependency('prawn-manual_builder', ">= 0.2.0")
-  spec.add_development_dependency('pdf-reader', '~>1.2')
+  spec.add_development_dependency('prawn-manual_builder', ">= 0.3.0")
 
   spec.homepage = "https://github.com/prawnpdf/prawn-table"
   spec.description = <<END_DESC


### PR DESCRIPTION
This PR adjusts the width calculation to utilize the new method added in PR prawnpdf/prawn#1259 so that fallback_fonts are considered when determining the width of a piece of text.

potential issues (to be resolved in a later PR in the core prawn)
- this uses a hard-coded 10,000 width when calculating the max width.  If a PDF of greater than that width is ever created this would not correctly work.
  - in order to fix this, a better method would need to be created in the prawn core that would calculate the width with fallback fonts and NOT do line-wrapping.  (would require some refactoring in the core).

TODO
- [ ] increase minimum required version of prawn once the other PR is released.