### PR TITLE
Add font_size Feature to PrawnTable's Text Cell

### DIFF
--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -44,6 +44,11 @@ module Prawn
           @text_options[:style] = style
         end
 
+        # Set the font size
+        def font_size=(size)
+          @text_options[:size] = size
+        end
+
         # Returns the width of this text with no wrapping. This will be far off
         # from the final width if the text is long.
         #

--- a/spec/table/cell/text_spec.rb
+++ b/spec/table/cell/text_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+require File.join(File.expand_path(File.dirname(__FILE__)), "..", "..", "spec_helper")
+require 'set'
+
+describe Prawn::Table::Cell::Text do
+  let(:pdf) { Prawn::Document.new }
+  let(:data) { "Text data" }
+  let(:options) { { :font_size => 12 } }
+  let(:cell) { Prawn::Table::Cell::Text.new(pdf, [0, 0], :content => data, :text_options => options) }
+
+  describe "#font_size=" do
+    it "sets the font size in the text options" do
+      new_font_size = 10
+      cell.font_size = new_font_size
+      expect(cell.instance_variable_get("@text_options")[:size]).to eq(new_font_size)
+    end
+  end
+end


### PR DESCRIPTION
Hi Great Developers!

I added font_size method. This feature introduces the ability to directly set the font_size for text cells, providing more control over the appearance of tables.

Feature Description:
The font_size property allows users to specify the size of the font used within a table cell. This feature is in line with the library's goal of offering robust and flexible styling options for PDF table generation.

Thanks!