### PR TITLE
Implement Static Defined Headers

### DIFF
--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -142,8 +142,13 @@ module Prawn
       @pdf = document
       @cells = make_cells(data, table_opts.delete(:cell_style) || {})
       @header = false
+      @headers = nil
       table_opts.each do |k, v|
         send("#{k}=", v) if respond_to?("#{k}=")
+      end
+
+      unless @headers.nil?
+        @headers = make_cells(@headers, table_opts.delete(:cell_style) || {})
       end
 
       if block
@@ -229,6 +234,8 @@ module Prawn
     #
     attr_writer :header
 
+    attr_accessor :headers
+
     # Accepts an Array of alternating row colors to stripe the table.
     #
     attr_writer :row_colors
@@ -295,6 +302,10 @@ module Prawn
         # Track cells to be drawn on this page. They will all be drawn when this
         # page is finished.
         cells_this_page = []
+
+        if !@headers.nil? && @header && @pdf.page_count == 1
+          add_header(@pdf.cursor, cells_this_page)
+        end
 
         @cells.each do |cell|
           if start_new_page?(cell, offset, ref_bounds)
@@ -506,7 +517,11 @@ module Prawn
     def header_rows
       header_rows = Cells.new
       number_of_header_rows.times do |r|
-        row(r).each { |cell| header_rows[cell.row, cell.column] = cell.dup }
+        if @headers.nil?
+          row(r).each { |cell| header_rows[cell.row, cell.column] = cell.dup }
+        else
+          headers.row(r).each { |cell| header_rows[cell.row, cell.column] = cell.dup }
+        end
       end
       header_rows
     end
@@ -673,13 +688,19 @@ module Prawn
       # Calculate x- and y-positions as running sums of widths / heights.
       x_positions = column_widths.inject([0]) { |ary, x|
         ary << (ary.last + x); ary }[0..-2]
-      x_positions.each_with_index { |x, i| column(i).x = x }
+      x_positions.each_with_index do |x, i|
+        column(i).x = x
+        headers.column(i).x = x unless headers.nil? || headers.column(i).nil?
+      end
 
       # y-positions assume an infinitely long canvas starting at zero -- this
       # is corrected for in Table#draw, and page breaks are properly inserted.
       y_positions = row_heights.inject([0]) { |ary, y|
         ary << (ary.last - y); ary}[0..-2]
-      y_positions.each_with_index { |y, i| row(i).y = y }
+      y_positions.each_with_index do |y, i|
+        row(i).y = y
+        headers.row(i).y = y unless headers.nil? || headers.row(i).nil?
+      end
     end
 
     # Sets up a bounding box to position the table according to the specified

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -676,6 +676,9 @@ module Prawn
       column_widths.each_with_index do |w, col_num|
         column(col_num).width = w
       end
+      if !headers.nil?
+        headers.column(col_num).width = w
+      end
     end
 
     # Assigns the row heights to each cell. This ensures that every cell in a
@@ -683,6 +686,9 @@ module Prawn
     #
     def set_row_heights
       row_heights.each_with_index { |h, row_num| row(row_num).height = h }
+      if !headers.nil?
+        row_heights.each_with_index { |h, row_num| headers.row(row_num).height = h }
+      end
     end
 
     # Set each cell's position based on the widths and heights of cells

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -69,6 +69,10 @@ module Prawn
   #   numbering (for styling and other row-specific options) always indexes
   #   based on your data array. Whether or not you have a header, row(n) always
   #   refers to the nth element (starting from 0) of the +data+ array.
+  # +headers+::
+  #   If set to a multidimensional array of data, the defined header will be
+  #   repeated on every page.
+  #   +header+ must also be set to +true+ for this to function.
   # +column_widths+::
   #   Sets widths for individual columns. Manually setting widths can give
   #   better results than letting Prawn guess at them, as Prawn's algorithm
@@ -234,6 +238,10 @@ module Prawn
     #
     attr_writer :header
 
+    # If set to a valid multidimensional array of data the data specified here
+    # will be used on each page as the header. +header+ must be set to +true+
+    # for this to function.
+    #
     attr_accessor :headers
 
     # Accepts an Array of alternating row colors to stripe the table.

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -677,9 +677,6 @@ module Prawn
         column(col_num).width = w
         headers.column(col_num).width = w if !headers.nil? && !headers.column(col_num).nil?
       end
-      if !headers.nil?
-        headers.column(col_num).width = w
-      end
     end
 
     # Assigns the row heights to each cell. This ensures that every cell in a

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -311,10 +311,6 @@ module Prawn
         # page is finished.
         cells_this_page = []
 
-        if !@headers.nil? && @header && @pdf.page_count == 1
-          add_header(@pdf.cursor, cells_this_page)
-        end
-
         @cells.each do |cell|
           if start_new_page?(cell, offset, ref_bounds)
             # draw cells on the current page and then start a new one

--- a/lib/prawn/table.rb
+++ b/lib/prawn/table.rb
@@ -675,6 +675,7 @@ module Prawn
     def set_column_widths
       column_widths.each_with_index do |w, col_num|
         column(col_num).width = w
+        headers.column(col_num).width = w if !headers.nil? && !headers.column(col_num).nil?
       end
       if !headers.nil?
         headers.column(col_num).width = w
@@ -685,9 +686,9 @@ module Prawn
     # row is the same height.
     #
     def set_row_heights
-      row_heights.each_with_index { |h, row_num| row(row_num).height = h }
-      if !headers.nil?
-        row_heights.each_with_index { |h, row_num| headers.row(row_num).height = h }
+      row_heights.each_with_index do |h, row_num|
+        row(row_num).height = h
+        headers.row(row_num).height = h if !headers.nil? && !headers.row(row_num).nil?
       end
     end
 

--- a/prawn-table.gemspec
+++ b/prawn-table.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('prawn-dev', '~> 0.3.0')
   spec.add_development_dependency('prawn-manual_builder', ">= 0.2.0")
   spec.add_development_dependency('pdf-reader', '~>1.2')
+  spec.add_development_dependency('matrix')
 
   spec.homepage = "https://github.com/prawnpdf/prawn-table"
   spec.description = <<END_DESC

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1153,6 +1153,17 @@ describe "Prawn::Table" do
           data.flatten[-2..-1]
       end
 
+      it "should repeat defined headers across pages" do
+        data = [["foo","bar"]] * 31
+        headers = [["baz","foobar"]]
+        @pdf = Prawn::Document.new
+        @pdf.table(data, :header => true, :headers => headers)
+        output = PDF::Inspector::Text.analyze(@pdf.render)
+        expect(@pdf.page_count).to eq 2
+        expect(output.strings).to eq headers.flatten + data.flatten[0..-3] + headers.flatten +
+                                       data.flatten[-2..-1]
+      end
+
       it "draws headers at the correct position" do
         data = [["header"]] + [["foo"]] * 40
 

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1154,13 +1154,14 @@ describe "Prawn::Table" do
       end
 
       it "should repeat defined headers across pages" do
-        data = [["foo","bar"]] * 31
-        headers = [["baz","foobar"]]
+        data = [["foo","bar"]] * 30
+        first_page_headers = [["bazbar", "foobaz"]]
+        repeating_headers = [["baz","foobar"]]
         @pdf = Prawn::Document.new
-        @pdf.table(data, :header => true, :headers => headers)
+        @pdf.table(first_page_headers + data, :header => true, :headers => repeating_headers)
         output = PDF::Inspector::Text.analyze(@pdf.render)
         expect(@pdf.page_count).to eq 2
-        expect(output.strings).to eq headers.flatten + data.flatten[0..-3] + headers.flatten +
+        expect(output.strings).to eq first_page_headers.flatten + data.flatten[0..-3] + repeating_headers.flatten +
                                        data.flatten[-2..-1]
       end
 


### PR DESCRIPTION
An issue we have run into recently when building a PDF from a large set of data is memory usage.

We can alleviate this issue by creating tables in smaller chunks of the data with something like the below

```ruby
@table_data.each_slice(500).with_index do |batch, i|
  doc.table(batch, width: doc.bounds.width) do
    #styling
  end
end
```

After implementing the above our memory usage was lowered from ~2.5gb to about 600mb. Great, but it introduced an issue for us.

The formatting still works, we don't end up with random page breaks. This issue is that it breaks the ability to use the headers option, because after the first chunk of data the first line is no longer the actual header.

This PR implements a `headers` option which can be used like the below

```ruby
header_data = [table_data.first]
table_data.each_slice(500).with_index do |batch, i|
  doc.table(batch, header: true, headers: header_data, width: doc.bounds.width) do
    # same styling as before
    # you can also independently style the header cells themselves
    headers.size = 8
    headers.borders = []
    headers.padding = [0, 5, 5, 0]

    # and the individual columns of the header
    headers.column(0).width = doc.bounds.width * 0.08

    # and the rows
    headers.row(0).font_style = :bold
  end
end
```

I'd like to get thoughts on this. I'm not sure if there is anything I'm missing here. I did try to generate the manual in this branch, but ran into some errors when doing so.